### PR TITLE
Add FastAPI news fetcher with Celery

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,40 @@
-# Houzeo-weather
+# News API Fetcher
+
+This project uses FastAPI and Celery to periodically fetch news articles from the [News API](https://newsapi.org/) and store them in a MySQL database.
+
+## Requirements
+
+- Python 3.11+
+- MySQL database
+- Redis (for Celery broker and backend)
+
+Install Python dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Running the API
+
+Create the environment variables `NEWS_API_KEY` and `DATABASE_URL` pointing to your News API key and MySQL database respectively. Example:
+
+```bash
+export NEWS_API_KEY=your_api_key
+export DATABASE_URL=mysql+pymysql://user:password@localhost/newsdb
+```
+
+Start the FastAPI server:
+
+```bash
+uvicorn app.main:app --reload
+```
+
+## Running the Celery worker
+
+Start a Redis server then run:
+
+```bash
+celery -A app.tasks worker -B --loglevel=info
+```
+
+The `-B` flag enables Celery Beat which schedules the periodic task every minute.

--- a/app/database.py
+++ b/app/database.py
@@ -1,0 +1,9 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, declarative_base
+import os
+
+DATABASE_URL = os.environ.get("DATABASE_URL", "mysql+pymysql://user:password@localhost/newsdb")
+
+engine = create_engine(DATABASE_URL)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+Base = declarative_base()

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,26 @@
+from fastapi import FastAPI
+from .database import engine, Base
+from .models import NewsArticle
+
+Base.metadata.create_all(bind=engine)
+
+app = FastAPI(title="News Fetcher")
+
+@app.get("/articles")
+def list_articles():
+    from .database import SessionLocal
+    session = SessionLocal()
+    try:
+        articles = session.query(NewsArticle).order_by(NewsArticle.published_at.desc()).all()
+        return [
+            {
+                "id": a.id,
+                "title": a.title,
+                "description": a.description,
+                "url": a.url,
+                "published_at": a.published_at,
+            }
+            for a in articles
+        ]
+    finally:
+        session.close()

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,11 @@
+from sqlalchemy import Column, Integer, String, Text, DateTime
+from .database import Base
+
+class NewsArticle(Base):
+    __tablename__ = "news_articles"
+
+    id = Column(Integer, primary_key=True, index=True)
+    title = Column(String(512))
+    description = Column(Text)
+    url = Column(String(1024))
+    published_at = Column(DateTime)

--- a/app/news_api.py
+++ b/app/news_api.py
@@ -1,0 +1,31 @@
+import os
+import requests
+from datetime import datetime
+from .database import SessionLocal
+from .models import NewsArticle
+
+NEWS_API_KEY = os.environ.get("NEWS_API_KEY", "")
+NEWS_API_URL = "https://newsapi.org/v2/top-headlines"
+
+
+def fetch_top_headlines(country="us"):
+    params = {"apiKey": NEWS_API_KEY, "country": country}
+    response = requests.get(NEWS_API_URL, params=params)
+    response.raise_for_status()
+    return response.json()
+
+
+def save_articles(data):
+    session = SessionLocal()
+    try:
+        for article in data.get("articles", []):
+            news = NewsArticle(
+                title=article.get("title"),
+                description=article.get("description"),
+                url=article.get("url"),
+                published_at=datetime.fromisoformat(article.get("publishedAt", "").replace("Z", "+00:00")) if article.get("publishedAt") else None,
+            )
+            session.add(news)
+        session.commit()
+    finally:
+        session.close()

--- a/app/tasks.py
+++ b/app/tasks.py
@@ -1,0 +1,19 @@
+import os
+from celery import Celery
+from .news_api import fetch_top_headlines, save_articles
+
+celery_app = Celery(
+    "worker",
+    broker=os.environ.get("CELERY_BROKER_URL", "redis://localhost:6379/0"),
+    backend=os.environ.get("CELERY_RESULT_BACKEND", "redis://localhost:6379/0"),
+)
+
+@celery_app.on_after_configure.connect
+def setup_periodic_tasks(sender, **kwargs):
+    # runs every minute
+    sender.add_periodic_task(60.0, fetch_and_store.s())
+
+@celery_app.task
+def fetch_and_store():
+    data = fetch_top_headlines()
+    save_articles(data)

--- a/celery_worker.py
+++ b/celery_worker.py
@@ -1,0 +1,4 @@
+from app.tasks import celery_app
+
+if __name__ == "__main__":
+    celery_app.start()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+fastapi
+uvicorn[standard]
+celery
+requests
+SQLAlchemy
+pymysql


### PR DESCRIPTION
## Summary
- add FastAPI project skeleton
- fetch news from News API and store it in MySQL
- run a Celery beat task every minute to fetch news
- document setup and execution steps

## Testing
- `python -m pip install -r requirements.txt`
- `python -m py_compile app/*.py celery_worker.py`

------
https://chatgpt.com/codex/tasks/task_b_6852e684c9c4832d90df6e8cf0875aa5